### PR TITLE
Improve testing; resolve deprecations and linter issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ script:
   - tox
 env:
   - TOXENV=linters
-  - TOXENV=functional
+  - TOXENV=functional_1.9.4
+  - TOXENV=functional_2.1.0
+  - TOXENV=functional_stable
 notifications:
   slack:
     rooms:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+unbound_package_state: latest
+
 unbound_upstream_resolvers:
   - 4.2.2.1
   - 4.2.2.2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,7 @@
 # Detect whether the init system is upstart of systemd.
 - name: Check init system
   command: cat /proc/1/comm
+  changed_when: false
   register: _pid1_name
   tags:
     - always

--- a/tasks/unbound_install_apt.yml
+++ b/tasks/unbound_install_apt.yml
@@ -27,18 +27,10 @@
   tags:
     - unbound-apt-packages
 
-- name: Ensure host can talk to HTTPS apt repos
-  apt:
-    pkg: "apt-transport-https"
-    state: latest
-    update_cache: yes
-  tags:
-    - unbound-apt-packages
-
 - name: Install unbound packages
   apt:
     pkg: "{{ item }}"
-    state: latest
+    state: "{{ unbound_package_state }}"
   register: install_packages
   until: install_packages | success
   retries: 5

--- a/tasks/unbound_install_yum.yml
+++ b/tasks/unbound_install_yum.yml
@@ -16,7 +16,7 @@
 - name: Install unbound yum packages
   yum:
     pkg: "{{ item }}"
-    state: latest
+    state: "{{ unbound_package_state }}"
   register: install_packages
   until: install_packages|success
   retries: 5

--- a/tasks/unbound_post_install.yml
+++ b/tasks/unbound_post_install.yml
@@ -36,7 +36,7 @@
     mode: '0644'
   notify:
     - Restart unbound
-  with_items: unbound_configuration_templates
+  with_items: "{{ unbound_configuration_templates }}"
   tags:
     - unbound-config
 
@@ -49,7 +49,7 @@
     mode: '0644'
   notify:
     - Restart unbound
-  with_items: unbound_records
+  with_items: "{{ unbound_records }}"
   tags:
     - unbound-config
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.0
 skipsdist = True
-envlist = linters,functional
+envlist = linters,functional_1.9.4,functional_2.1.0,functional_stable
 
 
 [testenv]
@@ -103,8 +103,6 @@ commands =
 [testenv:ansible]
 deps =
     {[testenv]deps}
-    ansible==1.9.4
-    ansible-lint>=2.7.0,<3.0.0
 setenv =
     {[testenv]setenv}
     ANSIBLE_HOST_KEY_CHECKING = False
@@ -131,14 +129,41 @@ commands =
                    --role-file={toxinidir}/tests/ansible-role-requirements.yml \
                    --force
 
-
-[testenv:ansible-syntax]
+[testenv:ansible_1.9.4]
 deps =
     {[testenv:ansible]deps}
+    ansible==1.9.4
 setenv =
     {[testenv:ansible]setenv}
 commands =
     {[testenv:ansible]commands}
+
+[testenv:ansible_2.1.0]
+deps =
+    {[testenv:ansible]deps}
+    ansible==2.1.0
+setenv =
+    {[testenv:ansible]setenv}
+commands =
+    {[testenv:ansible]commands}
+
+[testenv:ansible_stable]
+deps =
+    {[testenv:ansible]deps}
+    ansible
+    ansible-lint
+setenv =
+    {[testenv:ansible]setenv}
+commands =
+    {[testenv:ansible]commands}
+
+[testenv:ansible-syntax]
+deps =
+    {[testenv:ansible_stable]deps}
+setenv =
+    {[testenv:ansible_stable]setenv}
+commands =
+    {[testenv:ansible_stable]commands}
     ansible-playbook -i {toxinidir}/tests/inventory \
                      --syntax-check \
                      --list-tasks \
@@ -148,34 +173,61 @@ commands =
 
 [testenv:ansible-lint]
 deps =
-    {[testenv:ansible]deps}
+    {[testenv:ansible_stable]deps}
 commands =
     ansible-lint {toxinidir}
 
 
-[testenv:functional]
-# NOTE(odyssey4me): this target does not use constraints because
-# it doesn't work in OpenStack-CI yet. Once that's fixed, we can
-# drop the install_command.
+[testenv:functional_1.9.4]
 install_command =
     pip install -U --force-reinstall {opts} {packages}
 deps =
-    {[testenv:ansible]deps}
+    {[testenv:ansible_1.9.4]deps}
 setenv =
-    {[testenv:ansible]setenv}
+    {[testenv:ansible_1.9.4]setenv}
 commands =
-    {[testenv:ansible]commands}
+    {[testenv:ansible_1.9.4]commands}
     ansible-playbook -i {toxinidir}/tests/inventory \
                      -e "rolename={toxinidir}" \
                      -e "install_test_packages=True" \
                      {toxinidir}/tests/test.yml -vvvv
 
 
+[testenv:functional_2.1.0]
+install_command =
+   pip install -U --force-reinstall {opts} {packages}
+deps =
+   {[testenv:ansible_2.1.0]deps}
+setenv =
+   {[testenv:ansible_2.1.0]setenv}
+commands =
+   {[testenv:ansible_2.1.0]commands}
+   ansible-playbook -i {toxinidir}/tests/inventory \
+                    -e "rolename={toxinidir}" \
+                    -e "install_test_packages=True" \
+                    {toxinidir}/tests/test.yml -vvvv
+
+
+[testenv:functional_stable]
+install_command =
+   pip install -U --force-reinstall {opts} {packages}
+deps =
+   {[testenv:ansible_stable]deps}
+setenv =
+   {[testenv:ansible_stable]setenv}
+commands =
+   {[testenv:ansible_stable]commands}
+   ansible-playbook -i {toxinidir}/tests/inventory \
+                    -e "rolename={toxinidir}" \
+                    -e "install_test_packages=True" \
+                    {toxinidir}/tests/test.yml -vvvv
+
+
 [testenv:linters]
 deps =
-    {[testenv:ansible]deps}
+    {[testenv:ansible_stable]deps}
 setenv =
-    {[testenv:ansible]setenv}
+    {[testenv:ansible_stable]setenv}
 commands =
     {[testenv:pep8]commands}
     {[testenv:bashate]commands}


### PR DESCRIPTION
Adds tox scenarios for ansible 1.9.4, 2.1.0, and latest stable.

Runs linter using latest stable ansible.

Resolves var deprecations and linter issues
