### PR TITLE
Fix config dest path if absolute path is used

### DIFF
--- a/tasks/unbound_post_install.yml
+++ b/tasks/unbound_post_install.yml
@@ -30,7 +30,7 @@
 - name: Drop unbound local configurations
   template:
     src: "{{ item.template }}.j2"
-    dest: "{{ unbound_conf_dir }}/{{ (item.priority|default('50')|string).rjust(3, '0') }}-{{ item.template }}"
+    dest: "{{ unbound_conf_dir }}/{{ (item.priority|default('50')|string).rjust(3, '0') }}-{{ item.template | basename }}"
     owner: root
     group: root
     mode: '0644'


### PR DESCRIPTION
The template source path can be an absolute path, which would
cause the destination path to be broken.
