### PR TITLE
Fix apt update cache conditional

### DIFF
--- a/tasks/unbound_install_apt.yml
+++ b/tasks/unbound_install_apt.yml
@@ -23,7 +23,7 @@
 - name: Update apt if needed
   apt:
     update_cache: yes
-  when: "ansible_date_time.epoch|float - apt_cache_stat.stat.mtime > {{cache_timeout}}"
+  when: ansible_date_time.epoch|float - apt_cache_stat.stat.mtime > cache_timeout
   tags:
     - unbound-apt-packages
 


### PR DESCRIPTION
This terribly written conditional worked in ansible <2.2.
Now it's properly broken and this commit should fix it.

Please note that this trick is NOT required anymore in
ansible 2.2, so it's possible to remove these tasks
if meta/main.yml moves to a minimum version of 2.2.