### PR TITLE
Change to ansible_host in openstack.conf.j2

### DIFF
--- a/templates/openstack.conf.j2
+++ b/templates/openstack.conf.j2
@@ -2,11 +2,11 @@
 
 server:
 {% for container in groups['all'] %}
-  {%- if hostvars[container]['ansible_ssh_host'] is defined %}
-	local-data: "{{ container }}.{{ unbound_regional_zone }} A {{ hostvars[container]['ansible_ssh_host'] }}"
+  {%- if hostvars[container]['ansible_host'] is defined %}
+	local-data: "{{ container }}.{{ unbound_regional_zone }} A {{ hostvars[container]['ansible_host'] }}"
   {% set target_rfc_1034_1035_name = container|replace('_', '-') %}
 	{% if target_rfc_1034_1035_name != container %}
-	local-data: "{{ target_rfc_1034_1035_name }}.{{ unbound_regional_zone }} A {{ hostvars[container]['ansible_ssh_host'] }}"
+	local-data: "{{ target_rfc_1034_1035_name }}.{{ unbound_regional_zone }} A {{ hostvars[container]['ansible_host'] }}"
 	{% endif %}
 	{% endif %}
 {% endfor %}
@@ -15,14 +15,14 @@ server:
   {% if nova_live_migration_interface is defined and hostvars[container]['ansible_' + nova_live_migration_interface] is defined and hostvars[container]['ansible_' + nova_live_migration_interface]['active'] == true %}
 	local-data: "{{ container }}-lm.{{ unbound_regional_zone }} A {{ hostvars[container]['ansible_' + nova_live_migration_interface]['ipv4']['address'] }}"
   {% else %}
-	local-data: "{{ container }}-lm.{{ unbound_regional_zone }} A {{ hostvars[container]['ansible_ssh_host'] }}"
+	local-data: "{{ container }}-lm.{{ unbound_regional_zone }} A {{ hostvars[container]['ansible_host'] }}"
   {% endif %}
 {% endfor %}
 
 {% for group_name in groups | difference(['all', 'all_containers']) %}
   {%- for container in groups[group_name] %}
-	  {%- if hostvars[container]['ansible_ssh_host'] is defined %}
-        local-data: "{{ group_name }}.{{ unbound_regional_zone }} A {{ hostvars[container]['ansible_ssh_host'] }}"
+	  {%- if hostvars[container]['ansible_host'] is defined %}
+        local-data: "{{ group_name }}.{{ unbound_regional_zone }} A {{ hostvars[container]['ansible_host'] }}"
 		{% endif %}
   {% endfor %}
 {% endfor %}


### PR DESCRIPTION
When trying to run unbound playbook in OpenStack Ansible stable/ocata it fails due to the ansible_ssh_host variable not being set.

TASK [unbound : Drop unbound local configurations] *****************************
Wednesday 15 February 2017  22:41:32 +0000 (0:00:00.558)       0:00:08.497 **** 
changed: [infra01_unbound_container-7b5948e8] => (item={u'priority': 0, u'template': u'server.conf'})
changed: [infra03_unbound_container-630eeae7] => (item={u'priority': 0, u'template': u'server.conf'})
changed: [infra02_unbound_container-f2233888] => (item={u'priority': 0, u'template': u'server.conf'})
failed: [infra02_unbound_container-f2233888] (item={u'template': u'openstack.conf'}) => {"failed": true, "item": {"template": "openstack.conf"}, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'ansible_ssh_host'"}
failed: [infra03_unbound_container-630eeae7] (item={u'template': u'openstack.conf'}) => {"failed": true, "item": {"template": "openstack.conf"}, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'ansible_ssh_host'"}
failed: [infra01_unbound_container-7b5948e8] (item={u'template': u'openstack.conf'}) => {"failed": true, "item": {"template": "openstack.conf"}, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'ansible_ssh_host'"}