### PR TITLE
Clone the correct plugins branch

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -114,9 +114,11 @@ setenv =
     # This is required as the default is '/etc/ansible/roles' or a path
     # specified in ansible.cfg
     ANSIBLE_ROLES_PATH = {homedir}/.ansible/roles:{toxinidir}/..
+    PLUGINS_BRANCH = master
 commands =
     rm -rf {homedir}/.ansible/plugins
-    git clone https://git.openstack.org/openstack/openstack-ansible-plugins \
+    git clone -b {env:PLUGINS_BRANCH} \
+              https://git.openstack.org/openstack/openstack-ansible-plugins \
               {homedir}/.ansible/plugins
     rm -rf {homedir}/.ansible/roles
     ansible-galaxy install \
@@ -129,6 +131,7 @@ deps =
     ansible==2.1.5.0
 setenv =
     {[testenv:ansible]setenv}
+    PLUGINS_BRANCH = stable/newton
 commands =
     {[testenv:ansible]commands}
 
@@ -138,6 +141,7 @@ deps =
     ansible==2.2.2.0
 setenv =
     {[testenv:ansible]setenv}
+    PLUGINS_BRANCH = stable/ocata
 commands =
     {[testenv:ansible]commands}
 
@@ -179,7 +183,6 @@ deps =
    {[testenv:ansible_2.1]deps}
 setenv =
    {[testenv:ansible_2.1]setenv}
-   PLUGINS_BRANCH = stable/newton
 commands =
    {[testenv:ansible_2.1]commands}
    ansible-playbook -i {toxinidir}/tests/inventory \
@@ -194,7 +197,6 @@ deps =
    {[testenv:ansible_2.2]deps}
 setenv =
    {[testenv:ansible_2.2]setenv}
-   PLUGINS_BRANCH = stable/ocata
 commands =
    {[testenv:ansible_2.2]commands}
    ansible-playbook -i {toxinidir}/tests/inventory \


### PR DESCRIPTION
On old ansible versions, the correct OSA plugins branch should be
cloned.