### PR TITLE
Update to stop ansible deprecation warnings:

### DIFF
--- a/tasks/unbound_install.yml
+++ b/tasks/unbound_install.yml
@@ -20,7 +20,7 @@
     update_cache: "{{ (ansible_pkg_mgr in ['apt', 'zypper']) | ternary('yes', omit) }}"
     cache_valid_time: "{{ (ansible_pkg_mgr == 'apt') | ternary(cache_timeout, omit) }}"
   register: install_packages
-  until: install_packages | success
+  until: install_packages is success
   retries: 5
   delay: 2
 


### PR DESCRIPTION
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using
`result|success` use `result is success`. This feature will be removed in
version 2.9. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.